### PR TITLE
Fix bulk message deletion.

### DIFF
--- a/src/plaintextPatches.ts
+++ b/src/plaintextPatches.ts
@@ -38,7 +38,7 @@ const patches: types.PlaintextPatch[] = [
       {
         // Add deleted=true to all target messages in the MESSAGE_DELETE_BULK event
         match:
-          /MESSAGE_DELETE_BULK:function\((\w)\){var [\s\S]*?((?:\w{1,2}\.){2})getOrCreate[\s\S]*?},/,
+          /MESSAGE_DELETE_BULK:function\((\w)\){\n*var [\s\S]*?((?:\w{1,2}\.){2})getOrCreate[\s\S]*?},/,
         replace:
           "MESSAGE_DELETE_BULK:function($1){" +
           "   var cache = $2getOrCreate($1.channelId);" +


### PR DESCRIPTION
This pull request fixes an issue with bulk message deletion. For more information on the issue, please look at https://discord.com/channels/1000926524452647132/1000955966520557689/1151346405403787306 in the replugged discord. This issue stems from the fact that the bundler provides no guarantees of where it *could* place the newline. In this case, a discord update caused an issue. However it could work perfectly fine from now on. Keep in mind for an actual fix, you would need to litter possible new lines in so many locations nothing would even be slightly legible.